### PR TITLE
Add ogg group and pvb plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "drupal/migrate_plus": "^5.1",
         "drupal/migrate_source_csv": "^3.4",
         "drupal/migrate_tools": "^5.0",
+        "drupal/og": "^1.0@alpha",
         "drupal/pantheon_advanced_page_cache": "^2.1",
         "drupal/paragraphs": "^1.12",
         "drupal/pathauto": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2626fa7fe8e3c1c9a9cd883cc4f1e134",
+    "content-hash": "2033f74c91b8047ec3a788b9b1d3ea82",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2906,6 +2906,105 @@
                 "source": "https://git.drupalcode.org/project/migrate_tools",
                 "issues": "https://www.drupal.org/project/issues/migrate_tools",
                 "slack": "#migrate"
+            }
+        },
+        {
+            "name": "drupal/og",
+            "version": "1.0.0-alpha10",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/og.git",
+                "reference": "8.x-1.0-alpha10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/og-8.x-1.0-alpha10.zip",
+                "reference": "8.x-1.0-alpha10",
+                "shasum": "8f474c912e569e5d1dbe780556adcaa339291519"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10"
+            },
+            "require-dev": {
+                "drupal/coder": "^8.3.16",
+                "phpunit/phpunit": "^7 || ^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0-alpha10",
+                    "datestamp": "1669023300",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "amitaibu",
+                    "homepage": "https://www.drupal.org/u/amitaibu"
+                },
+                {
+                    "name": "mpp",
+                    "homepage": "https://www.drupal.org/u/mpp"
+                },
+                {
+                    "name": "pfrenssen",
+                    "homepage": "https://www.drupal.org/u/pfrenssen"
+                },
+                {
+                    "name": "dww",
+                    "homepage": "https://www.drupal.org/user/46549"
+                },
+                {
+                    "name": "Grayside",
+                    "homepage": "https://www.drupal.org/user/346868"
+                },
+                {
+                    "name": "joelpittet",
+                    "homepage": "https://www.drupal.org/user/160302"
+                },
+                {
+                    "name": "merlinofchaos",
+                    "homepage": "https://www.drupal.org/user/26979"
+                },
+                {
+                    "name": "moshe weitzman",
+                    "homepage": "https://www.drupal.org/user/23"
+                },
+                {
+                    "name": "mpp",
+                    "homepage": "https://www.drupal.org/user/359881"
+                },
+                {
+                    "name": "pfrenssen",
+                    "homepage": "https://www.drupal.org/user/382067"
+                },
+                {
+                    "name": "RoySegall",
+                    "homepage": "https://www.drupal.org/user/1812910"
+                },
+                {
+                    "name": "sethcohn",
+                    "homepage": "https://www.drupal.org/user/14944"
+                },
+                {
+                    "name": "Zen",
+                    "homepage": "https://www.drupal.org/user/21209"
+                }
+            ],
+            "description": "API to allow associating content with groups.",
+            "homepage": "https://drupal.org/project/og",
+            "support": {
+                "source": "https://git.drupalcode.org/project/og",
+                "issues": "https://drupal.org/project/issues/og",
+                "irc": "irc://irc.freenode.org/drupal-og",
+                "slack": "https://drupal.slack.com/messages/CELR48EA0"
             }
         },
         {
@@ -13149,6 +13248,7 @@
         "drupal/config_ignore": 10,
         "drupal/elasticsearch_connector": 15,
         "drupal/emptyparagraphkiller": 15,
+        "drupal/og": 15,
         "drupal/drupal_test_assertions": 20
     },
     "prefer-stable": true,

--- a/config/sync/core.base_field_override.node.group.promote.yml
+++ b/config/sync/core.base_field_override.node.group.promote.yml
@@ -1,0 +1,22 @@
+uuid: b9805fff-6cff-4012-b9aa-56319ea65ed3
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.group
+id: node.group.promote
+field_name: promote
+entity_type: node
+bundle: group
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.entity_form_display.node.group.default.yml
+++ b/config/sync/core.entity_form_display.node.group.default.yml
@@ -1,0 +1,106 @@
+uuid: aec9201a-d8ae-4374-83ca-6be7c5458f00
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.group.body
+    - field.field.node.group.field_featured_image
+    - node.type.group
+  module:
+    - path
+    - select2
+    - text
+id: node.group.default
+targetEntityType: node
+bundle: group
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 121
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_featured_image:
+    type: select2_entity_reference
+    weight: 122
+    region: content
+    settings:
+      width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 15
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 120
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 16
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_view_display.node.group.default.yml
+++ b/config/sync/core.entity_view_display.node.group.default.yml
@@ -1,0 +1,47 @@
+uuid: a1058a94-6aae-4316-985d-da1dc7860c82
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.group.body
+    - field.field.node.group.field_featured_image
+    - node.type.group
+  module:
+    - og
+    - text
+    - user
+id: node.group.default
+targetEntityType: node
+bundle: group
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 101
+    region: content
+  field_featured_image:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 102
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+  og_group:
+    type: og_group_subscribe
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.group.teaser.yml
+++ b/config/sync/core.entity_view_display.node.group.teaser.yml
@@ -1,0 +1,42 @@
+uuid: 46ad2b57-75dc-4db7-931b-a6c74a1cd05c
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.group.body
+    - field.field.node.group.field_featured_image
+    - node.type.group
+  module:
+    - og
+    - text
+    - user
+id: node.group.teaser
+targetEntityType: node
+bundle: group
+mode: teaser
+content:
+  body:
+    type: text_summary_or_trimmed
+    label: hidden
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    weight: 101
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+  og_group:
+    type: og_group_subscribe
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_featured_image: true
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -49,6 +49,8 @@ module:
   menu_ui: 0
   mysql: 0
   node: 0
+  og: 0
+  og_ui: 0
   options: 0
   page_cache: 0
   pantheon_advanced_page_cache: 0

--- a/config/sync/field.field.node.group.body.yml
+++ b/config/sync/field.field.node.group.body.yml
@@ -1,0 +1,23 @@
+uuid: 3459b4dd-d8b8-4c05-b43f-d19e733010c8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.group
+  module:
+    - text
+id: node.group.body
+field_name: body
+entity_type: node
+bundle: group
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+field_type: text_with_summary

--- a/config/sync/field.field.node.group.field_featured_image.yml
+++ b/config/sync/field.field.node.group.field_featured_image.yml
@@ -1,0 +1,29 @@
+uuid: 4fce11d2-337c-4119-ab86-cb53d44a0cbd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_featured_image
+    - media.type.image
+    - node.type.group
+id: node.group.field_featured_image
+field_name: field_featured_image
+entity_type: node
+bundle: group
+label: 'Featured image'
+description: 'Group image'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/language.content_settings.node.group.yml
+++ b/config/sync/language.content_settings.node.group.yml
@@ -1,0 +1,11 @@
+uuid: 1028463c-ee59-4f75-8591-6ce18c9e32f6
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.group
+id: node.group
+target_entity_type_id: node
+target_bundle: group
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/node.type.group.yml
+++ b/config/sync/node.type.group.yml
@@ -1,0 +1,17 @@
+uuid: bcba781c-5e1f-4860-ac52-1213d932ee4e
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: Group
+type: group
+description: 'Example Organic group content type for job application at Gizra.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/config/sync/og.og_role.node-group-administrator.yml
+++ b/config/sync/og.og_role.node-group-administrator.yml
@@ -1,0 +1,15 @@
+uuid: 5558a402-5250-45d9-bac5-5bf974ddf523
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.group
+id: node-group-administrator
+label: Administrator
+weight: 2
+group_id: null
+group_type: node
+group_bundle: group
+is_admin: true
+permissions: {  }
+role_type: null

--- a/config/sync/og.og_role.node-group-member.yml
+++ b/config/sync/og.og_role.node-group-member.yml
@@ -1,0 +1,15 @@
+uuid: f4da888c-16a7-4159-b77d-cdf4cb6e90a3
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.group
+id: node-group-member
+label: Member
+weight: 1
+group_id: null
+group_type: node
+group_bundle: group
+is_admin: null
+permissions: {  }
+role_type: required

--- a/config/sync/og.og_role.node-group-non-member.yml
+++ b/config/sync/og.og_role.node-group-non-member.yml
@@ -1,0 +1,16 @@
+uuid: 3467db56-cb9a-4762-bf3e-f713d1feaf13
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.group
+id: node-group-non-member
+label: Non-member
+weight: null
+group_id: null
+group_type: node
+group_bundle: group
+is_admin: null
+permissions:
+  - subscribe
+role_type: required

--- a/config/sync/og.settings.yml
+++ b/config/sync/og.settings.yml
@@ -1,0 +1,16 @@
+_core:
+  default_config_hash: 3r2emFI83HVYv-o5sOIr3nycGMAXflzJR_3-8myD--k
+groups:
+  node:
+    - group
+group_manager_full_access: true
+node_access_strict: true
+delete_orphans: false
+delete_orphans_plugin_id: simple
+deny_subscribe_without_approval: true
+group_resolvers:
+  - route_group
+  - route_group_content
+  - request_query_argument
+  - user_access
+auto_add_group_owner_membership: true

--- a/web/modules/custom/server_general/src/NodeGroupTrait.php
+++ b/web/modules/custom/server_general/src/NodeGroupTrait.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\server_general;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Drupal\og\OgMembershipInterface;
+
+
+/**
+ * Trait NodeGroupTrait - helper for building OG group field.
+ *
+ * @package Drupal\server_general
+ */
+trait NodeGroupTrait {
+
+  /**
+   * @param \Drupal\node\NodeInterface $entity
+   *   Node entity.
+   * @param \Drupal\Core\Session\AccountInterface $currentUser
+   *   Current user account.
+   * @param bool $override
+   *   Flag that enables output override if TRUE.
+   * @param string $field_name
+   *   Computed OG group field name.
+   *
+   * @return array
+   *   Rendered array.
+   */
+  public function buildOgGroupField(NodeInterface $entity, AccountInterface $currentUser, bool $override, string $field_name = 'og_group'): array {
+
+    // If override is enabled we present user with different OG group field message.
+    if ($override) {
+
+      // Get OG group subscribe route.
+      $parameters = [
+        'entity_type_id' => $entity->getEntityTypeId(),
+        'group' => $entity->id(),
+        'og_membership_type' => OgMembershipInterface::TYPE_DEFAULT,
+      ];
+      $url = Url::fromRoute('og.subscribe', $parameters);
+
+      $og_group_field = [
+        '#theme' => 'server_theme_node_group__og_group_field',
+        '#title' => $this->t('Hi @name, click here if you would like to subscribe to this group called @label', ['@name' => $currentUser->getDisplayName(), '@label' => $entity->getTitle()]),
+        '#link' => $url ?? '',
+      ];
+    }
+    else {
+      // We present user with default OG group field rendered output.
+      // Check: web/modules/contrib/og/src/Plugin/Field/FieldFormatter/GroupSubscribeFormatter.php.
+      $og_group_field_renderable_array = $entity->get($field_name)->view();
+      $og_group_field = !empty($og_group_field_renderable_array) ? $og_group_field_renderable_array : [];
+    }
+
+    return $og_group_field;
+  }
+
+}

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeGroup.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeGroup.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\server_general\Plugin\EntityViewBuilder;
+
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\intl_date\IntlDate;
+use Drupal\node\Entity\NodeType;
+use Drupal\node\NodeInterface;
+use Drupal\og\OgAccessInterface;
+use Drupal\og\MembershipManagerInterface;
+use Drupal\og\OgMembershipInterface;
+use Drupal\pluggable_entity_view_builder\Annotation\EntityViewBuilder;
+use Drupal\server_general\EntityDateTrait;
+use Drupal\server_general\EntityViewBuilder\NodeViewBuilderAbstract;
+use Drupal\server_general\LineSeparatorTrait;
+use Drupal\server_general\SocialShareTrait;
+use Drupal\server_general\TitleAndLabelsTrait;
+use Drupal\server_general\NodeGroupTrait;
+use Drupal\user\EntityOwnerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+
+/**
+ * The "OG Group" EVB plugin.
+ *
+ * @EntityViewBuilder(
+ *   id = "node.group",
+ *   label = @Translation("OG - Group"),
+ *   description = "Node view builder for OG Group."
+ * )
+ */
+class NodeGroup extends NodeViewBuilderAbstract implements ContainerFactoryPluginInterface {
+
+  use EntityDateTrait;
+  use LineSeparatorTrait;
+  use SocialShareTrait;
+  use TitleAndLabelsTrait;
+  use NodeGroupTrait;
+
+  /**
+   * OG group settings.
+   *
+   * @var array $og_group_settings
+   */
+  protected array $og_group_settings = [
+    'override_og_group_field' => FALSE,
+  ];
+
+  /**
+   * The OG access service.
+   *
+   * @var \Drupal\og\OgAccessInterface
+   */
+  protected OgAccessInterface $ogAccess;
+
+  /**
+   * The OG membership service.
+   *
+   * @var \Drupal\og\MembershipManagerInterface
+   */
+  protected MembershipManagerInterface $ogMembershipManager;
+
+
+  /**
+   * NodeGroup constructor.
+   *
+   * @param array $configuration
+   * @param $plugin_id
+   * @param $plugin_definition
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   * @param \Drupal\og\OgAccessInterface $ogAccess
+   * @param \Drupal\og\MembershipManagerInterface $ogMembershipManager
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, EntityRepositoryInterface $entity_repository, OgAccessInterface $ogAccess, MembershipManagerInterface $ogMembershipManager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $entity_repository);
+
+    $this->ogAccess = $ogAccess;
+    $this->ogMembershipManager = $ogMembershipManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('current_user'),
+      $container->get('entity.repository'),
+      $container->get('og.access'),
+      $container->get('og.membership_manager'),
+    );
+  }
+
+  /**
+   * Build full view mode.
+   *
+   * @param array $build
+   *   The existing build.
+   * @param \Drupal\node\NodeInterface $entity
+   *   The entity.
+   *
+   * @return array
+   *   Render array.
+   */
+  public function buildFull(array $build, NodeInterface $entity) {
+    $elements = [];
+
+    // Header.
+    $element = $this->buildHeader($entity);
+    $elements[] = $this->wrapContainerWide($element);
+
+    // Og Group computed field holding (un)subscribe link.
+    $this->og_group_settings['override_og_group_field'] = $this->checkMembershipAndSubscribeAccess($entity, $this->currentUser);
+    $element = $this->buildOgGroupField($entity, $this->currentUser, $this->og_group_settings['override_og_group_field']);
+    $elements[] = $this->wrapContainerWide($element);
+
+    // Main content and sidebar.
+    $element = $this->buildMainAndSidebar($entity);
+    $elements[] = $this->wrapContainerWide($element);
+
+    $elements = $this->wrapContainerVerticalSpacingBig($elements);
+    $build[] = $this->wrapContainerBottomPadding($elements);
+
+    return $build;
+  }
+
+  /**
+   * Build the header.
+   *
+   * @param \Drupal\node\NodeInterface $entity
+   *   The entity.
+   *
+   * @return array
+   *   Render array
+   *
+   * @throws \IntlException
+   */
+  protected function buildHeader(NodeInterface $entity): array {
+    $elements = [];
+
+    // Build page title.
+    $elements[] = $this->buildConditionalPageTitle($entity);
+
+    // Show the node type as a label.
+    $node_type = NodeType::load($entity->bundle());
+    $elements[] = $this->buildLabelsFromText([$node_type->label()]);
+
+    // Date.
+    $timestamp = $this->getFieldOrCreatedTimestamp($entity, 'field_publish_date');
+    $element = IntlDate::formatPattern($timestamp, 'long');
+
+    // Make text bigger.
+    $elements[] = $this->wrapTextResponsiveFontSize($element, 'lg');
+
+    $elements = $this->wrapContainerVerticalSpacing($elements);
+
+    return $this->wrapContainerNarrow($elements);
+  }
+
+  /**
+   * Build the Main content and the sidebar.
+   *
+   * @param \Drupal\node\NodeInterface $entity
+   *   The entity.
+   *
+   * @return array
+   *   Render array
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  protected function buildMainAndSidebar(NodeInterface $entity): array {
+    $main_elements = [];
+    $sidebar_elements = [];
+    $social_share_elements = [];
+
+    // Get the body text, wrap it with `prose` so it's styled.
+    // NOTE: Function buildProcessedText has wrong default field value:
+    // "field_body" instead of "body" so we pass correct value.
+    $main_elements[] = $this->buildProcessedText($entity, 'body');
+
+    // Get the tags, and social share.
+    $sidebar_elements[] = $this->buildTags($entity);
+
+    // Show the featured image.
+    $medias = $entity->get('field_featured_image')->referencedEntities();
+    $sidebar_elements[] = $this->wrapContainerVerticalSpacing($this->buildEntities($medias, 'full'));
+
+    // Add a line separator above the social share buttons.
+    $social_share_elements[] = $this->buildLineSeparator();
+    $social_share_elements[] = $this->buildSocialShare($entity);
+
+    $sidebar_elements[] = $this->wrapContainerVerticalSpacing($social_share_elements);
+
+    return [
+      '#theme' => 'server_theme_main_and_sidebar',
+      '#main' => $this->wrapContainerVerticalSpacingBig($main_elements),
+      '#sidebar' => $this->wrapContainerVerticalSpacingBig($sidebar_elements),
+    ];
+
+  }
+
+
+  /**
+   * Helper - Checks OG group subscribe access and membership status.
+   *
+   * If user is authenticated and NOT group admin and is not group member
+   * already, we enable OG group field content override.
+   *
+   * @param \Drupal\node\NodeInterface $entity
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *
+   * @return bool
+   *   Returns TRUE if OG group field should be overridden.
+   */
+  private function checkMembershipAndSubscribeAccess(NodeInterface $entity, AccountInterface $account) {
+    $override = FALSE;
+
+    if ($account->isAuthenticated() && ($entity instanceof EntityOwnerInterface) && ($entity->getOwnerId() != $account->id())) {
+      if (!$this->ogMembershipManager->getMembership($entity, $account->id(), OgMembershipInterface::ALL_STATES)) {
+          $override = TRUE;
+      }
+    }
+
+    return $override;
+  }
+
+}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralOgGroupTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralOgGroupTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\node\NodeInterface;
+use Drupal\og\Og;
+use Drupal\og\OgMembershipInterface;
+use Drupal\user\UserInterface;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * An OG group model test case using traits from Drupal Test Traits.
+ */
+class ServerGeneralOgGroupTest extends ExistingSiteBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static array $modules = [
+    'node',
+    'og',
+    'options',
+    'pluggable_entity_view_builder',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected string $defaultTheme = 'server_theme';
+
+  /**
+   * Test entity group.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
+  protected NodeInterface $group;
+
+  /**
+   * A group bundle name.
+   *
+   * @var string
+   */
+  protected string $groupBundle;
+
+  /**
+   * A non-author user.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected UserInterface $user;
+
+  /**
+   * An author user.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected UserInterface $author;
+
+
+  /**
+   * {@inheritdoc}
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Create OG group node author user.
+    $this->author = $this->createUser();
+
+    // Create non-author user.
+    $this->user = $this->createUser();
+
+    // Set our custom entity type bundle name.
+    $this->groupBundle = 'group';
+
+    // Check if OG group entity type already exists or not.
+    try {
+      if ($content_type = \Drupal::entityTypeManager()
+        ->getStorage('node_type')
+        ->load($this->groupBundle)) {
+        // Create node of our custom OG group type and set author.
+        $this->group = $this->createNode([
+          'type' => $this->groupBundle,
+          'title' => $this->randomString(),
+          'uid' => $this->author->id(),
+        ]);
+
+      }
+    } catch (InvalidPluginDefinitionException $e) {
+    } catch (PluginNotFoundException $e) {
+    }
+
+  }
+
+  /**
+   * Tests the OG group field formatter changes by user and membership.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public function testOgFormatter() {
+    // Get assert session.
+    $assert = $this->assertSession();
+
+    // Get OG group node URL.
+    $url = $this->group->toUrl();
+
+    // Test OG group node URL.
+    $assert->assert(!empty($url), 'OG group node URL is empty!');
+
+    // Test contents of OG group field for OG group node author user.
+    $this->drupalLogin($this->author);
+    $this->drupalGet($url);
+    $author_membership = Og::getMembership($this->group, $this->author, OgMembershipInterface::ALL_STATES);
+    $assert->assert(!is_null($author_membership), 'Group author should be already a group member!');
+    // This is default text shown to the group owner.
+    // In the case of author user we don't have link.
+    $assert->pageTextContains('You are the group manager');
+
+    // Test for overridden OG group field text for logged-in user.
+    $this->drupalLogin($this->user);
+    // User shouldn't already be a member of the group.
+    $user_membership = Og::getMembership($this->group, $this->user, OgMembershipInterface::ALL_STATES);
+    $assert->assert(is_null($user_membership), 'Logged in user is already a member of the group!');
+    $this->drupalGet($url);
+    // Create string based on current user name and OG group name.
+    $label = strtr('Hi @name, click here if you would like to subscribe to this group called @label', [
+      '@name' => $this->user->getDisplayName(),
+      '@label' => $this->group->getTitle(),
+    ]);
+    $assert->linkExists($label);
+
+    // Anonymous user should still see original text from OG group field formatter.
+    $this->drupalLogout();
+    $this->drupalGet($url);
+    $assert->linkExists('Request group membership');
+  }
+
+}

--- a/web/themes/custom/server_theme/server_theme.theme
+++ b/web/themes/custom/server_theme/server_theme.theme
@@ -437,6 +437,14 @@ function server_theme_theme() {
     'variables' => [],
   ];
 
+  // Adding OG group field alternative title and link variables.
+  $info['server_theme_node_group__og_group_field'] = [
+    'variables' => [
+      'title' => NULL,
+      'link' => NULL,
+    ],
+  ];
+
   return $info;
 }
 

--- a/web/themes/custom/server_theme/templates/server-theme-node-group--og-group-field.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-node-group--og-group-field.html.twig
@@ -1,0 +1,4 @@
+<div class="field field--name-og-group field--type-og-group field--label-above">
+  <div class="field__label">OG Group</div>
+  <div class="field__item border-2 border-black"><a href="{{ link }}">{{ title }}</a></div>
+</div>


### PR DESCRIPTION
This PR is for the purpose of Gizra's [home assignment](https://www.gizra.com/jobs/candidates-info/) for Drupal dev position (BE part). In order to test it you should:

-  clone this repo
- switch to add_ogg_group_and_pvb_plugin branch
- run command "ddev composer install"
- run command "cp .ddev/config.local.yaml.example .ddev/config.local.yaml"
- run command: "ddev restart"
- in order to run test you should: "ddev drush cr && ddev phpunit --verbose --filter ServerGeneralOgGroupTest"
- for manual testing you should create new content node of type "Group" and then visit that node as logged in user that is not the author of the mentioned node. Below you can see 3 situations and how OG group field looks like for different users:

**1) Og group content type**

![001_gizra_ha_og_group_content_type](https://user-images.githubusercontent.com/34510055/210816126-b76af54e-8347-4344-84a1-2dc4015c1a71.png)

**2) Adding node of OG group type**

![002_gizra_ha_og_group_content_node](https://user-images.githubusercontent.com/34510055/210816221-49365800-2a72-453d-9ab6-2ba044707c9f.png)

**3) Node created + view from node author user**

![003_gizra_ha_og_group_content_node_created](https://user-images.githubusercontent.com/34510055/210816339-0cfe30fd-160a-422d-bce0-f01aeaea29ab.png)

**4) Group node as seen from anonymous user (showing default og group field)**

![004_gizra_ha_og_group_content_node_anonymous_user](https://user-images.githubusercontent.com/34510055/210816465-4155a3a6-87ad-4427-b201-4e9a4acd8153.png)

**5) Group node as seen from logged-in user that is not the node author (offering to request subscription but with overridden content showing username and group name)**

![005_gizra_ha_og_group_content_node_logged_user](https://user-images.githubusercontent.com/34510055/210816747-29460dff-2d14-4b78-854c-63d51443fd59.png)

**This is based on Entity View Builder plugin that is overriding OG group entity display based on user role, login and group membership status. Styling is added just to make distinction for this message content as this was actually the task requirement.**

**6) Result of OG group test file**

![006_gizra_ha_og_group_test](https://user-images.githubusercontent.com/34510055/210816864-88fda89f-ef6f-4702-a76b-7a8fbfc56cf7.png)



