### PR TITLE
Add person card styling

### DIFF
--- a/web/modules/custom/server_general/src/BadgeTrait.php
+++ b/web/modules/custom/server_general/src/BadgeTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\server_general;
+
+/**
+ * Helper methods for wrapping element inside badge.
+ */
+trait BadgeTrait {
+
+  /**
+   * Wrap element inside a rounded corner badge.
+   *
+   * @param string $item
+   *   Badge text content e.g. role like "admin" etc.
+   *
+   * @param string $color
+   *   Badge color.
+   *
+   * @return array
+   *   Themed badge render array.
+   */
+  protected function wrapElementRoundedBadge(string $item, string $color): array {
+    return [
+      '#theme' => 'server_theme_badge',
+      '#color' => $color,
+      '#item' => $item,
+    ];
+  }
+
+}

--- a/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
+++ b/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
@@ -3,11 +3,13 @@
 namespace Drupal\server_style_guide\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Utility\LinkGenerator;
 use Drupal\media\IFrameUrlHelper;
 use Drupal\node\Entity\Node;
 use Drupal\pluggable_entity_view_builder\BuildFieldTrait;
+use Drupal\server_general\BadgeTrait;
 use Drupal\server_general\ButtonTrait;
 use Drupal\server_general\CardTrait;
 use Drupal\server_general\ElementTrait;
@@ -37,6 +39,7 @@ class StyleGuideController extends ControllerBase {
   use StyleGuideElementWrapTrait;
   use TagTrait;
   use TitleAndLabelsTrait;
+  use BadgeTrait;
 
   /**
    * The link generator service.
@@ -98,6 +101,12 @@ class StyleGuideController extends ControllerBase {
   protected function getAllElements() : array {
     $build = [];
 
+    $element = $this->getPersonCardGrid(1);
+    $build[] = $this->wrapElementWideContainer($element, 'Person card');
+
+    $element = $this->getPersonCardGrid(10);
+    $build[] = $this->wrapElementWideContainer($element, 'Person card\'s');
+
     $element = $this->getPageTitle();
     $build[] = $this->wrapElementWideContainer($element, 'Page title');
 
@@ -144,6 +153,216 @@ class StyleGuideController extends ControllerBase {
     $build[] = $this->wrapElementWideContainer($element, 'Media: Video');
 
     return $build;
+  }
+
+  /**
+   * Method that returns themed person card.
+   *
+   * @return array
+   *  Render array of person card.
+   */
+  protected function getPersonCard(): array {
+
+    return $this->buildPersonCard($this->getRandomPerson());
+  }
+
+  /**
+   * Get a random person's data for demo purpose.
+   *
+   * @return array
+   *   A random person's data array.
+   */
+  protected function getRandomPerson(): array {
+
+    $firstnames = [
+      'Gifford',
+      'Grant',
+      'Grayson',
+      'Gregory',
+      'Gresham',
+      'Griswald',
+      'Grover',
+      'Guy',
+      'Hadden',
+      'Hadley',
+      'Hadwin',
+      'Hal',
+    ];
+
+    $lastnames = [
+      'Fisher',
+      'Fletcher',
+      'Grady',
+      'Hunter',
+      'Jacoby',
+      'Jagger',
+      'Jaxon',
+      'Jett',
+      'Kade',
+    ];
+
+    $job_titles = [
+      'Doctor (GP)',
+      'Doctor (Hospital)',
+      'DramaTherapist',
+      'Economist',
+      'Editorial Assistant',
+      'Education Administrator',
+      'Electrical Engineer',
+    ];
+
+    $roles = [
+      'admin',
+      'content admin',
+      'content editor',
+      'recruiter',
+    ];
+
+    // Url used for link inside person image.
+    $url = Url::fromRoute('<front>');
+
+    $elements = [];
+
+    // Person image.
+    $image = [
+      '#theme' => 'image',
+      '#uri' => $this->getPlaceholderPersonImage(128),
+      '#width' => 128,
+    ];
+
+    // Image should be clickable.
+    $image = [
+      '#type' => 'html_tag',
+      '#tag' => 'a',
+      '#value' =>  \Drupal::service('renderer')->render($image),
+      '#attributes' => ['href' => $url->toString()],
+    ];
+
+    // Add person image to leading content information section.
+    $leading_content_elements[] = $this->wrapRoundedCornersFull($image);
+
+    // Generate person name and surname (also used for email).
+    $first_name = $firstnames[array_rand($firstnames)];
+    $last_name = $lastnames[array_rand($lastnames)];
+
+    $inner_elements[] = ['#markup' => $first_name . ' ' . $last_name];
+
+    // Generate job title.
+    $inner_elements[] = $this->wrapTextColor(['#markup' => $job_titles[array_rand($job_titles)]], 'light-gray');
+
+    // Generate person role and warp it inside badge.
+    $role = $roles[array_rand($roles)];
+    $inner_elements[] = $this->wrapElementRoundedBadge($role, 'green');
+
+    // Add rest of person information to leading content information section.
+    $leading_content_elements[] = $this->wrapContainerVerticalSpacingTiny($inner_elements, 'center');
+
+    // Add leading content information data to main elements array.
+    $elements[] = $this->wrapElementPersonCardLeadingContent($leading_content_elements);
+
+    // Build action links like email, call. Twig is created so that it can potentially accept more then 2 elements.
+    $icon_elements[] = $this->buildLinkWithIcon('Email', strtolower($first_name . '.' . $last_name . '@company.com'), 'email');
+    $icon_elements[] = $this->buildLinkWithIcon('Call', mt_rand(11111111,99999999), 'call');
+
+    // Add actions as gid to the main elements array.
+    $elements[] = $this->buildLinkWithIconGrid($icon_elements);
+
+    return $elements;
+  }
+
+  /**
+   * Builds link with icon in front of text.
+   *
+   * @param string $title
+   *  Link title.
+   * @param string $url_value
+   *  Value used in url like email address or phone number.
+   * @param string $action
+   *  Actual action like call, email which determines link value and icon.
+   *
+   * @return array
+   *  Render array of link with icon.
+   */
+  protected function buildLinkWithIcon(string $title, string $url_value, string $action): array {
+    return [
+      '#theme' => 'server_theme_link_with_icon',
+      '#title' => $title,
+      '#url_value' => $url_value,
+      '#action' => $action,
+    ];
+  }
+
+  /**
+   * Creates a grid of links with icons.
+   *
+   * @param array $items
+   *  Icon with link render arrays.
+   *
+   * @return array
+   *  Render array of links with icons in a grid.
+   */
+  protected function buildLinkWithIconGrid(array $items): array {
+    return [
+      '#theme' => 'server_theme_link_with_icon_grid',
+      '#items' => $items,
+    ];
+  }
+
+  /**
+   * Builds person card from given items.
+   *
+   * @param array $items
+   *  Array of render array(s).
+   *
+   * @return array
+   *  Render array of person card.
+   */
+  protected function buildPersonCard(array $items): array {
+
+    return [
+      '#theme' => 'server_theme_card__person',
+      '#items' => $items,
+    ];
+  }
+
+  /**
+   * Wraps person card leading content info to be separate from action links.
+   *
+   * @param array $items
+   *   Array of render array(s).
+   *
+   * @return array
+   *  Render array of items themed for leading content section.
+   */
+  protected function wrapElementPersonCardLeadingContent(array $items): array {
+
+    return [
+      '#theme' => 'server_theme_card__person_leading_content',
+      '#items' => $items,
+    ];
+  }
+
+  /**
+   * Generates a grid of person cards based on number.
+   *
+   * @param int $size
+   *  Number of person cards to generate for demo.
+   *
+   * @return array
+   *  Render array of items in a grid.
+   */
+  protected function getPersonCardGrid(int $size): array {
+
+    $items = [];
+
+    for ($i = 0; $i < $size; $i++) {
+      $items[] = $this->getPersonCard();
+    }
+
+    return [
+      '#theme' => 'server_theme_card__person_grid',
+      '#items' => $items,
+    ];
   }
 
   /**
@@ -229,7 +448,8 @@ class StyleGuideController extends ControllerBase {
     $items = [];
     $url = Url::fromRoute('<front>');
 
-    $names = ['Jon Doe', 'Smith Allen', 'David Bowie'];
+    //    $names = ['Jon Doe', 'Smith Allen', 'David Bowie'];
+    $names = ['Jon Doe'];
     foreach ($names as $key => $name) {
       $elements = [];
       $element = [

--- a/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
+++ b/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
@@ -447,8 +447,7 @@ class StyleGuideController extends ControllerBase {
     $items = [];
     $url = Url::fromRoute('<front>');
 
-    //    $names = ['Jon Doe', 'Smith Allen', 'David Bowie'];
-    $names = ['Jon Doe'];
+    $names = ['Jon Doe', 'Smith Allen', 'David Bowie'];
     foreach ($names as $key => $name) {
       $elements = [];
       $element = [

--- a/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
+++ b/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
@@ -3,7 +3,6 @@
 namespace Drupal\server_style_guide\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Utility\LinkGenerator;
 use Drupal\media\IFrameUrlHelper;

--- a/web/themes/custom/server_theme/server_theme.theme
+++ b/web/themes/custom/server_theme/server_theme.theme
@@ -232,6 +232,54 @@ function server_theme_theme() {
     ],
   ];
 
+  // Person card.
+  $info['server_theme_card__person'] = [
+    'variables' => [
+      // A render array.
+      'items' => NULL,
+    ],
+  ];
+
+
+  // Multiple person cards as grid.
+  $info['server_theme_card__person_grid'] = [
+    'variables' => [
+      // A list of person cards.
+      'items' => [],
+    ],
+  ];
+
+  // Person card leading content section.
+  $info['server_theme_card__person_leading_content'] = [
+    'variables' => [
+      'items' => [],
+    ],
+  ];
+
+  // Badge wrap element.
+  $info['server_theme_badge'] = [
+    'variables' => [
+      'color' => NULL,
+      'item' => [],
+    ],
+  ];
+
+  // Action link with icon before.
+  $info['server_theme_link_with_icon'] = [
+    'variables' => [
+      'title' => NULL,
+      'url_value' => NULL,
+      'action' => NULL,
+    ],
+  ];
+
+  // Grid of action links with icons.
+  $info['server_theme_link_with_icon_grid'] = [
+    'variables' => [
+      'items' => NULL,
+    ],
+  ];
+
   // "Call to action" element.
   $info['server_theme_element__cta'] = [
     'variables' => [

--- a/web/themes/custom/server_theme/templates/server-theme-badge.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-badge.html.twig
@@ -1,0 +1,3 @@
+<span class="bg-{{ color }}-100 text-{{ color }}-800 text-xs font-medium mr-2 px-2.5 py-0.5 rounded-full dark:bg-{{ color }}-900 dark:text-{{ color }}-300">
+  {{ item }}
+</span>

--- a/web/themes/custom/server_theme/templates/server-theme-card--person-grid.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-card--person-grid.html.twig
@@ -1,0 +1,3 @@
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-8 md:gap-y-12 pb-10">
+  {{ items }}
+</div>

--- a/web/themes/custom/server_theme/templates/server-theme-card--person-leading-content.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-card--person-leading-content.html.twig
@@ -1,0 +1,3 @@
+<div class="pt-8 pb-8 flex items-center flex-col justify-center">
+  {{ items }}
+</div>

--- a/web/themes/custom/server_theme/templates/server-theme-card--person.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-card--person.html.twig
@@ -1,0 +1,5 @@
+{% import '@server_theme/templates/server-theme-card-base.html.twig' as base %}
+
+<div class="{{ base.getBaseClasses() }} grid place-items-center shadow-md">
+  {{ items }}
+</div>

--- a/web/themes/custom/server_theme/templates/server-theme-link-with-icon-grid.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-link-with-icon-grid.html.twig
@@ -1,0 +1,8 @@
+<div class="w-full h-14 border-t flex border-gray-200">
+  {% for item in items %}
+    <div
+      class="flex items-center justify-center items-center h-full w-1/{{ items|length }} pl-6 py-6 first:border-l-0 border-l border-gray-200 mt-0">
+      {{ item }}
+    </div>
+  {% endfor %}
+</div>

--- a/web/themes/custom/server_theme/templates/server-theme-link-with-icon.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-link-with-icon.html.twig
@@ -1,0 +1,25 @@
+{% if action == 'email' %}
+  {% set actionUrl = "mailto:" ~ url_value %}
+  {% set hover_title = 'Contact by Email'|t %}
+{% elseif action == 'call' %}
+  {% set actionUrl = "tel:" ~ url_value %}
+  {% set hover_title = 'Contact by Phone'|t %}
+{% endif %}
+
+{% macro getIcon(action) %}
+  {% if action == 'email' %}
+    <svg width="17" height="12" viewBox="0 0 17 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M0.753 1.884L8.75 5.882L16.747 1.884C16.7174 1.37444 16.4941 0.895488 16.1228 0.545227C15.7516 0.194965 15.2604 -9.35847e-05 14.75 3.36834e-08H2.75C2.23958 -9.35847e-05 1.74845 0.194965 1.37718 0.545227C1.00591 0.895488 0.782604 1.37444 0.753 1.884Z" fill="#9CA3AF"/>
+      <path d="M16.75 4.118L8.75 8.118L0.75 4.118V10C0.75 10.5304 0.960714 11.0391 1.33579 11.4142C1.71086 11.7893 2.21957 12 2.75 12H14.75C15.2804 12 15.7891 11.7893 16.1642 11.4142C16.5393 11.0391 16.75 10.5304 16.75 10V4.118Z" fill="#9CA3AF"/>
+    </svg>
+  {% elseif action == 'call' %}
+    <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M0.25 1C0.25 0.447715 0.697715 0 1.25 0H3.40287C3.89171 0 4.3089 0.353413 4.38927 0.835601L5.12858 5.27147C5.20075 5.70451 4.98206 6.13397 4.5894 6.3303L3.04126 7.10437C4.15756 9.87832 6.37168 12.0924 9.14563 13.2087L9.9197 11.6606C10.116 11.2679 10.5455 11.0492 10.9785 11.1214L15.4144 11.8607C15.8966 11.9411 16.25 12.3583 16.25 12.8471V15C16.25 15.5523 15.8023 16 15.25 16H13.25C6.0703 16 0.25 10.1797 0.25 3V1Z" fill="#9CA3AF"/>
+    </svg>
+  {% endif %}
+{% endmacro %}
+
+<a href="{{ actionUrl }}" target="_blank" title="{{ hover_title }}" class="flex items-center">
+  <span class="shrink-0 mr-3.5 text-gray-400">{{ _self.getIcon(action) }}</span>
+  <span class="text-gray-700 font-medium">{{ title }}</span>
+</a>


### PR DESCRIPTION
Second part of [home assignment](https://www.gizra.com/jobs/candidates-info/) for Gizra Drupal developer job application. Adds person card styling entry to style guide page. Style is not yet fine tuned to be 1:1 copy of Figma source https://www.figma.com/file/r1kH05IrINkSRPTDGi665K/Home-assignment---TailwindCSS

![gizra_person_card_single](https://user-images.githubusercontent.com/34510055/213201550-a6f2332c-bce7-42e5-b9c3-c4be22114ea1.png)

![gizra_person_card_grid](https://user-images.githubusercontent.com/34510055/213201574-e0673a1a-22c9-4516-bc14-22abe39f86c0.png)

